### PR TITLE
fix refresh speed after change node type in the editor

### DIFF
--- a/Barrel-react.js
+++ b/Barrel-react.js
@@ -709,7 +709,7 @@ var BarrelTabs = React.createClass({
                             appName={serviceTemplate.getAttribute("name")} />
                     </div>
                     <div className="tab-pane" id="editor">
-                        <BarrelEditor typeDocs={csar.getTypeDocuments()} onChange={() => this.forceUpdate()} />
+                        <BarrelEditor typeDocs={csar.getTypeDocuments()} onChange={() => {}} />
                     </div>
                     <div className="tab-pane" id="analyser">
                         <div>


### PR DESCRIPTION
I think that the `forceUpdate` of the `BarrelTabs` component is unnecessary when the node type is changed in the editor. Removing this increase a lot the reloading speed of the interface.