### PR TITLE
Fix 404 on null

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,11 +39,8 @@
     <!--JS Inline-->
     <script type="text/javascript">
         function qualifyURL(url) {
-            var img = document.createElement('img');
-	        img.src = url; // set string url
-	        url = img.src; // get qualified url
-	        img.src = null; // no server request
-	        return url;
+            var absolute = window.location.href;
+	        return absolute.substr(0, absolute.lastIndexOf("\/")+1) + url;
         }
         zip.workerScriptsPath = qualifyURL("lib/z-worker.js").slice(0, -("z-worker.js".length));
         var barrel = null;


### PR DESCRIPTION
The qualifyURL script was setting the img.src to null, causing a 404 error.
A better approach is to use the window.location.href to get the base url and concat it with the relative one.
If you prefer to maintain the same approach, take a look to the PR #13 instead.