### PR TITLE
Fix 404 on null

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,10 +39,9 @@
     <!--JS Inline-->
     <script type="text/javascript">
         function qualifyURL(url) {
-            var img = document.createElement('img');
-	        img.src = url; // set string url
-	        url = img.src; // get qualified url
-	        img.src = null; // no server request
+            var a = document.createElement('a');
+	        a.href = url; // set string url
+	        url = a.href; // get qualified url
 	        return url;
         }
         zip.workerScriptsPath = qualifyURL("lib/z-worker.js").slice(0, -("z-worker.js".length));


### PR DESCRIPTION
The qualifyURL script was setting the img.src to null, causing a 404 error.
Maintaining the same approach, the a element doesn't fire a server request.
Anyway, in my opinion, the PR #12 provide a better approach, and I suggest you to consider merging the other PR instead of that one.