### PR TITLE
Cherrypick last fixes from gh-pages to master

### DIFF
--- a/Barrel-visualiser.js
+++ b/Barrel-visualiser.js
@@ -142,7 +142,10 @@ Visualiser = React.createClass({
             }));
 
             // Create a new environment (see createGraph function definition)
-            var env = createGraph(parentDiv, 400, 600);
+            var graphWidth = 940;
+            var containers = document.getElementsByClassName("container");
+            if (containers.length) graphWidth = containers[0].offsetWidth - 30;
+            var env = createGraph(parentDiv, graphWidth, 600);
 
             // Create a cell for each node
             for (var n in nodes) {

--- a/index.html
+++ b/index.html
@@ -39,11 +39,8 @@
     <!--JS Inline-->
     <script type="text/javascript">
         function qualifyURL(url) {
-            var img = document.createElement('img');
-	        img.src = url; // set string url
-	        url = img.src; // get qualified url
-	        img.src = null; // no server request
-	        return url;
+            var absolute = window.location.href;
+	        return absolute.substr(0, absolute.lastIndexOf("\/")+1) + url;
         }
         zip.workerScriptsPath = qualifyURL("lib/z-worker.js").slice(0, -("z-worker.js".length));
         var barrel = null;


### PR DESCRIPTION
This is the cherrypick required in #11 and #12.

**Fix 404 on null** (3bab92e - a317ea8)
The qualifyURL script was setting the img.src to null, causing a 404 error.
A better approach is to use the window.location.href to get the base url and concat it with the relative one.

**Show a full-width graph in visualize** (4d3652f - 9333b75)
A large application topology causes the nodes that represent some of the components to end up outside the image canvas. This edit shows a full-width graph in the Visualize tab. This will put the table after the graph instead of aside, allowing to display a larger and more relaxed topology to improve the readability.
Note that this feature doesn't fix the bug: a very large topology will still causes the nodes to end up outside the canvas, even at full with. A possible fix could be to take the size passed to the createGraph function as max width and drow nodes inside that space. Then, by setting the svg width equal to the width used by the elements that it contains, you can obtain a smaller canvas with the table aside when possible, and a full-width canvas otherwise.